### PR TITLE
Fix character assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,13 @@ function randomId(len, pattern) {
 
   pattern.split('').forEach((a) => {
     if (!isNaN(parseInt(a))) {
-      chars = possibilities.numbers;
+      chars += possibilities.numbers;
     } else if (/[a-z]/.test(a)) {
-      chars = possibilities.lowerCased;
+      chars += possibilities.lowerCased;
     } else if (/[A-Z]/.test(a)) {
-      chars = possibilities.capitals;
+      chars += possibilities.capitals;
     } else {
-      chars = possibilities.special;
+      chars += possibilities.special;
     }
   });
 


### PR DESCRIPTION
Fix a bug in the current version of the library where only the last matched character in the specification determines which characters to use. For example, using "aA" results in just capitals.